### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,4 +1,6 @@
 name: Label issue
+permissions:
+  issues: write
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql-cli-binaries/security/code-scanning/1](https://github.com/krishnprakash/codeql-cli-binaries/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires the ability to add labels to issues, we will set the `issues` permission to `write` and restrict all other permissions by default. This can be done at the workflow level (applies to all jobs) or at the job level (applies to a specific job). In this case, we will add the `permissions` block at the workflow level for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
